### PR TITLE
Simplify project section presentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,18 +191,6 @@
                         <i class="fas fa-layer-group"></i>
                         Todos
                     </button>
-                    <button class="filter-btn" data-filter="Básico">
-                        <i class="fas fa-seedling"></i>
-                        Básico
-                    </button>
-                    <button class="filter-btn" data-filter="Avanzado">
-                        <i class="fas fa-chart-line"></i>
-                        Avanzado
-                    </button>
-                    <button class="filter-btn" data-filter="Profesional">
-                        <i class="fas fa-rocket"></i>
-                        Profesional
-                    </button>
                 </div>
                 <div class="projects-grid" id="projectsGrid" aria-live="polite"></div>
             </div>
@@ -309,10 +297,6 @@
                 <div class="modal-info">
                     <p id="modalDescription"></p>
                     <div id="modalTechnologies" class="modal-technologies"></div>
-                    <div class="modal-buttons">
-                        <a id="modalGithub" href="#" target="_blank" rel="noopener" class="project-link primary">Ver Código</a>
-                        <a id="modalDemo" href="#" target="_blank" rel="noopener" class="project-link secondary">Ver Demo</a>
-                    </div>
                 </div>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -75,28 +75,14 @@ function createProjectCard(project) {
     const card = document.createElement('div');
     card.className = 'project-card';
     card.onclick = () => openModal(project);
-    
+
     card.innerHTML = `
         <img src="${project.image}" alt="${project.title}" class="project-image">
         <div class="project-info">
-            <h3 class="project-title">${project.title}</h3>
             <p class="project-description">${project.description}</p>
-            <div class="project-tags">
-                ${project.tags.map(tag => `<span class="project-tag" data-tag="${tag}">${tag}</span>`).join('')}
-            </div>
-            <div class="project-links">
-                <a href="${project.github}" target="_blank" class="project-link primary" onclick="event.stopPropagation(); if(this.href === '#') { alert('Enlace no disponible'); return false; }">
-                    <i class="fab fa-github"></i>
-                    Ver Código
-                </a>
-                <a href="${project.demo}" target="_blank" class="project-link secondary" onclick="event.stopPropagation(); if(this.href === '#') { alert('Enlace no disponible'); return false; }">
-                    <i class="fas fa-external-link-alt"></i>
-                    Ver Demo
-                </a>
-            </div>
         </div>
     `;
-    
+
     return card;
 }
 
@@ -154,38 +140,16 @@ function openModal(project) {
     const modalImage = document.getElementById('modalImage');
     const modalDescription = document.getElementById('modalDescription');
     const modalTechnologies = document.getElementById('modalTechnologies');
-    const modalGithub = document.getElementById('modalGithub');
-    const modalDemo = document.getElementById('modalDemo');
-    
+
     modalTitle.textContent = project.title;
     modalImage.src = project.image;
     modalImage.alt = project.title;
     modalDescription.textContent = project.fullDescription;
-    
-    modalTechnologies.innerHTML = project.technologies.map(tech => 
+
+    modalTechnologies.innerHTML = project.technologies.map(tech =>
         `<span class="modal-tech-tag">${tech}</span>`
     ).join('');
-    
-    modalGithub.href = project.github;
-    modalDemo.href = project.demo;
-    
-    // Add click handlers for modal buttons
-    modalGithub.onclick = function(e) {
-        if (this.href === '#') {
-            e.preventDefault();
-            alert('Enlace no disponible');
-            return false;
-        }
-    };
-    
-    modalDemo.onclick = function(e) {
-        if (this.href === '#') {
-            e.preventDefault();
-            alert('Enlace no disponible');
-            return false;
-        }
-    };
-    
+
     modal.style.display = 'block';
     document.body.style.overflow = 'hidden';
     


### PR DESCRIPTION
## Summary
- Remove the extra filter buttons so only the "Todos" option is shown in the projects section
- Update project cards to display only the image and description, removing tags and external links
- Clean up the modal to drop the unused action buttons

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68de86c17334832cb2178c6306b85e1b