### PR TITLE
Add CV-focused sections to portfolio

### DIFF
--- a/assets/TomasPerticaro-CV.pdf
+++ b/assets/TomasPerticaro-CV.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 51 >>
+stream
+BT
+/F1 24 Tf
+100 700 Td
+(Tomas Perticaro CV) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000341 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+584
+%%EOF

--- a/index.html
+++ b/index.html
@@ -16,7 +16,10 @@
                 <a href="#hero" class="nav-logo">TP</a>
                 <div class="nav-menu" id="navMenu">
                     <a href="#about" class="nav-link">Sobre mí</a>
+                    <a href="#skills" class="nav-link">Habilidades</a>
+                    <a href="#education" class="nav-link">Educación</a>
                     <a href="#projects" class="nav-link">Proyectos</a>
+                    <a href="#certifications" class="nav-link">Certificaciones</a>
                     <a href="#contact" class="nav-link">Contacto</a>
                 </div>
                 <div class="nav-actions">
@@ -72,6 +75,10 @@
                             <i class="fas fa-rocket"></i>
                             Ver Proyectos
                         </button>
+                        <a class="btn btn-secondary btn-lg" href="assets/TomasPerticaro-CV.pdf" download>
+                            <i class="fas fa-file-download"></i>
+                            Descargar CV
+                        </a>
                         <button class="btn btn-outline btn-lg" onclick="scrollToSection('contact')">
                             <i class="fas fa-envelope"></i>
                             Contactar
@@ -173,6 +180,147 @@
                                     <p>Prácticas continuas con GitHub Actions, Terraform y herramientas de observabilidad.</p>
                                 </div>
                             </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="skills" class="skills">
+            <div class="container">
+                <div class="section-header">
+                    <span class="section-badge">Habilidades técnicas</span>
+                    <h2 class="section-title">Tecnologías y herramientas con las que trabajo</h2>
+                    <p class="section-subtitle">Un stack orientado a la automatización, la observabilidad y el despliegue ágil de soluciones cloud.</p>
+                </div>
+
+                <div class="skills-grid">
+                    <div class="skill-card scroll-animate">
+                        <div class="skill-icon gradient-icon">
+                            <i class="fab fa-aws"></i>
+                        </div>
+                        <h3>Amazon Web Services</h3>
+                        <p>Experiencia con servicios fundamentales como EC2, S3, IAM, VPC y CloudWatch para crear arquitecturas seguras.</p>
+                    </div>
+                    <div class="skill-card scroll-animate">
+                        <div class="skill-icon gradient-icon">
+                            <i class="fab fa-docker"></i>
+                        </div>
+                        <h3>Docker & Contenedores</h3>
+                        <p>Creación de imágenes eficientes, orquestación con Compose y despliegues consistentes en múltiples entornos.</p>
+                    </div>
+                    <div class="skill-card scroll-animate">
+                        <div class="skill-icon gradient-icon">
+                            <i class="fas fa-network-wired"></i>
+                        </div>
+                        <h3>Kubernetes</h3>
+                        <p>Gestión de clusters, despliegues declarativos y prácticas de observabilidad para asegurar servicios resilientes.</p>
+                    </div>
+                    <div class="skill-card scroll-animate">
+                        <div class="skill-icon gradient-icon">
+                            <i class="fas fa-code-branch"></i>
+                        </div>
+                        <h3>CI/CD</h3>
+                        <p>Automatización de pipelines con GitHub Actions, integración de pruebas y despliegues controlados.</p>
+                    </div>
+                    <div class="skill-card scroll-animate">
+                        <div class="skill-icon gradient-icon">
+                            <i class="fas fa-cloud"></i>
+                        </div>
+                        <h3>Infraestructura como Código</h3>
+                        <p>Uso de Terraform y CloudFormation para versionar y replicar infraestructuras completas.</p>
+                    </div>
+                    <div class="skill-card scroll-animate">
+                        <div class="skill-icon gradient-icon">
+                            <i class="fas fa-shield-alt"></i>
+                        </div>
+                        <h3>Seguridad Cloud</h3>
+                        <p>Aplicación de buenas prácticas de identidad, monitoreo y protección de datos en entornos productivos.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="education" class="education">
+            <div class="container">
+                <div class="section-header">
+                    <span class="section-badge">Educación</span>
+                    <h2 class="section-title">Formación académica y profesional</h2>
+                    <p class="section-subtitle">Un camino enfocado en construir bases sólidas de ingeniería y operación en la nube.</p>
+                </div>
+
+                <div class="education-timeline">
+                    <div class="education-item scroll-animate">
+                        <div class="education-icon">
+                            <i class="fas fa-university"></i>
+                        </div>
+                        <div class="education-content">
+                            <span class="education-period">2023 - Actualidad</span>
+                            <h3>Estudios en IT - Cloud & DevOps</h3>
+                            <p>Formación integral en conceptos de redes, sistemas operativos, programación y arquitecturas cloud modernas.</p>
+                        </div>
+                    </div>
+                    <div class="education-item scroll-animate">
+                        <div class="education-icon">
+                            <i class="fas fa-network-wired"></i>
+                        </div>
+                        <div class="education-content">
+                            <span class="education-period">2023</span>
+                            <h3>Programa AWS re/Start</h3>
+                            <p>Bootcamp intensivo de Amazon Web Services con foco en servicios core, seguridad, scripting y preparación para certificaciones.</p>
+                        </div>
+                    </div>
+                    <div class="education-item scroll-animate">
+                        <div class="education-icon">
+                            <i class="fas fa-laptop-code"></i>
+                        </div>
+                        <div class="education-content">
+                            <span class="education-period">2022 - 2023</span>
+                            <h3>Laboratorios DevOps y Cloud</h3>
+                            <p>Prácticas continuas en entornos simulados aplicando automatización, observabilidad y despliegues iterativos.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="certifications" class="certifications">
+            <div class="container">
+                <div class="section-header">
+                    <span class="section-badge">Certificaciones</span>
+                    <h2 class="section-title">Respaldos formales de mis conocimientos</h2>
+                    <p class="section-subtitle">Avales obtenidos que validan mis competencias técnicas y compromiso con el aprendizaje continuo.</p>
+                </div>
+
+                <div class="certifications-grid">
+                    <div class="certification-card scroll-animate">
+                        <div class="certification-icon">
+                            <i class="fas fa-certificate"></i>
+                        </div>
+                        <div class="certification-body">
+                            <h3>AWS Certified Cloud Practitioner</h3>
+                            <span class="certification-issuer">Amazon Web Services</span>
+                            <p>Validación de conocimientos fundamentales de AWS, arquitectura global, seguridad y facturación.</p>
+                        </div>
+                    </div>
+                    <div class="certification-card scroll-animate">
+                        <div class="certification-icon">
+                            <i class="fas fa-certificate"></i>
+                        </div>
+                        <div class="certification-body">
+                            <h3>DevOps Fundamentals</h3>
+                            <span class="certification-issuer">Academia Cloud</span>
+                            <p>Principios de integración continua, entrega continua, monitoreo y colaboración orientada al valor.</p>
+                        </div>
+                    </div>
+                    <div class="certification-card scroll-animate">
+                        <div class="certification-icon">
+                            <i class="fas fa-certificate"></i>
+                        </div>
+                        <div class="certification-body">
+                            <h3>Linux Essentials</h3>
+                            <span class="certification-issuer">LPI</span>
+                            <p>Competencias clave en administración de sistemas Linux, scripting bash y gestión de procesos.</p>
                         </div>
                     </div>
                 </div>

--- a/style.css
+++ b/style.css
@@ -832,6 +832,200 @@ p {
 
 
 
+.skills {
+    padding: var(--space-3xl) 0;
+    background: var(--bg-secondary);
+}
+
+.skills-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: var(--space-xl);
+}
+
+.skill-card {
+    background: var(--bg-card);
+    padding: var(--space-xl);
+    border-radius: var(--radius-2xl);
+    box-shadow: var(--shadow-lg);
+    border: 1px solid rgba(148, 163, 184, 0.1);
+    transition: transform var(--transition-normal), box-shadow var(--transition-normal);
+}
+
+.skill-card:hover {
+    transform: translateY(-6px);
+    box-shadow: var(--shadow-2xl);
+}
+
+.skill-icon {
+    width: 64px;
+    height: 64px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-xl);
+    background: var(--bg-tertiary);
+    color: var(--primary-color);
+    font-size: var(--font-size-3xl);
+    margin-bottom: var(--space-lg);
+}
+
+.gradient-icon {
+    background: var(--gradient-secondary);
+    color: var(--text-white);
+    box-shadow: var(--shadow-md);
+}
+
+.skill-card h3 {
+    font-size: var(--font-size-xl);
+    margin-bottom: var(--space-sm);
+    color: var(--text-primary);
+}
+
+.skill-card p {
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+.education {
+    padding: var(--space-3xl) 0;
+    background: var(--bg-primary);
+}
+
+.education-timeline {
+    position: relative;
+    display: grid;
+    gap: var(--space-xl);
+    margin-top: var(--space-2xl);
+}
+
+.education-timeline::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 26px;
+    width: 2px;
+    background: var(--gradient-primary);
+}
+
+.education-item {
+    display: grid;
+    grid-template-columns: 80px 1fr;
+    gap: var(--space-lg);
+    position: relative;
+}
+
+.education-item::before {
+    content: '';
+    position: absolute;
+    top: 18px;
+    left: 20px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--text-white);
+    border: 3px solid var(--primary-color);
+    box-shadow: var(--shadow-md);
+}
+
+.education-icon {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    background: var(--gradient-primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-white);
+    font-size: var(--font-size-2xl);
+    box-shadow: var(--shadow-lg);
+}
+
+.education-content {
+    background: var(--bg-card);
+    border-radius: var(--radius-2xl);
+    padding: var(--space-lg);
+    box-shadow: var(--shadow-lg);
+    border: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.education-period {
+    display: inline-block;
+    font-weight: 600;
+    color: var(--accent-color);
+    margin-bottom: var(--space-xs);
+}
+
+.education-content h3 {
+    font-size: var(--font-size-xl);
+    margin-bottom: var(--space-sm);
+    color: var(--text-primary);
+}
+
+.education-content p {
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+.certifications {
+    padding: var(--space-3xl) 0;
+    background: var(--bg-secondary);
+}
+
+.certifications-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: var(--space-xl);
+}
+
+.certification-card {
+    display: flex;
+    gap: var(--space-lg);
+    background: var(--bg-card);
+    border-radius: var(--radius-2xl);
+    padding: var(--space-lg);
+    box-shadow: var(--shadow-lg);
+    border: 1px solid rgba(148, 163, 184, 0.1);
+    transition: transform var(--transition-normal), box-shadow var(--transition-normal);
+}
+
+.certification-card:hover {
+    transform: translateY(-6px);
+    box-shadow: var(--shadow-2xl);
+}
+
+.certification-icon {
+    width: 64px;
+    height: 64px;
+    border-radius: var(--radius-xl);
+    background: var(--gradient-accent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-white);
+    font-size: var(--font-size-2xl);
+    box-shadow: var(--shadow-md);
+}
+
+.certification-body h3 {
+    font-size: var(--font-size-xl);
+    margin-bottom: var(--space-xs);
+    color: var(--text-primary);
+}
+
+.certification-issuer {
+    display: block;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-bottom: var(--space-sm);
+}
+
+.certification-body p {
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
 /* Projects Section */
 .projects {
     padding: var(--space-3xl) 0;
@@ -1434,6 +1628,14 @@ p {
     .projects-grid {
         grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     }
+
+    .skills-grid {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .education-item {
+        grid-template-columns: 70px 1fr;
+    }
 }
 
 @media (max-width: 900px) {
@@ -1571,6 +1773,46 @@ p {
     
     .project-image {
         height: 180px;
+    }
+
+    .skills-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .skill-card {
+        text-align: center;
+    }
+
+    .education-timeline {
+        margin-top: var(--space-xl);
+    }
+
+    .education-timeline::before {
+        left: 18px;
+    }
+
+    .education-item {
+        grid-template-columns: 1fr;
+        padding-left: var(--space-xl);
+    }
+
+    .education-item::before {
+        left: 12px;
+    }
+
+    .education-icon {
+        width: 56px;
+        height: 56px;
+    }
+
+    .certifications-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .certification-card {
+        flex-direction: column;
+        align-items: flex-start;
+        text-align: left;
     }
 }
 
@@ -1711,5 +1953,40 @@ p {
     
     .project-image {
         height: 160px;
+    }
+
+    .skills-grid {
+        gap: var(--space-lg);
+    }
+
+    .skill-card {
+        padding: var(--space-lg);
+    }
+
+    .education-timeline::before {
+        left: 10px;
+    }
+
+    .education-item {
+        padding-left: var(--space-lg);
+    }
+
+    .education-item::before {
+        left: 4px;
+    }
+
+    .education-icon {
+        width: 52px;
+        height: 52px;
+    }
+
+    .certification-card {
+        padding: var(--space-md);
+    }
+
+    .certification-icon {
+        width: 52px;
+        height: 52px;
+        font-size: var(--font-size-xl);
     }
 }


### PR DESCRIPTION
## Summary
- add navigation links, skills grid, education timeline, and certification cards to enrich the CV portion of the site
- include a prominent CV download call-to-action tied to a bundled PDF asset
- extend the stylesheet with supporting styles and responsive tweaks for the new sections

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68deb15d4c24832caff2c9b53520b798