### PR TITLE
Improve hero badge text and desktop profile image

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
                 <div class="hero-text fade-in z-10 flex flex-1 flex-col gap-8 rounded-3xl border border-white/10 bg-slate-900/70 p-8 shadow-soft backdrop-blur">
                     <div class="hero-badge inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm font-semibold tracking-wide text-slate-100 shadow-soft">
                         <i class="fas fa-cloud text-accent"></i>
-                        <span>Estudiante IT | Cloud & DevOps</span>
+                        <span>Tomas Perticaro | Estudiante IT - Cloud &amp; DevOps</span>
                     </div>
                     <h1 class="hero-title text-4xl font-extrabold leading-tight md:text-5xl lg:text-6xl">
                         Aprendiendo y construyendo en <span class="gradient-text">Cloud &amp; DevOps</span>
@@ -83,7 +83,7 @@
                     <div class="hero-presentation flex flex-col items-start gap-6 sm:flex-row sm:items-center">
                         <div class="profile-image-container relative">
                             <div class="profile-border absolute inset-0 -rotate-6 rounded-3xl bg-gradient-to-br from-brand-500 via-accent to-emerald-300 opacity-70 blur-sm"></div>
-                            <div class="profile-image-frame relative z-10 h-28 w-28 rounded-3xl border-4 border-white/10 shadow-glow overflow-hidden">
+                            <div class="profile-image-frame relative z-10 rounded-3xl border-4 border-white/10 shadow-glow overflow-hidden">
                                 <img src="imagenes/20250114_170611.jpg" alt="Foto de Tomas Perticaro" class="profile-image h-full w-full">
                             </div>
                         </div>

--- a/style.css
+++ b/style.css
@@ -19,13 +19,31 @@ body {
     overflow: hidden;
     display: inline-flex;
     border-radius: 1.5rem;
+    width: 7rem;
+    height: 7rem;
+    flex-shrink: 0;
 }
 
 .profile-image {
+    display: block;
     width: 100%;
     height: 100%;
     object-fit: cover;
-    object-position: 50% 50%;
+    object-position: 50% 40%;
+}
+
+@media (min-width: 768px) {
+    .profile-image-frame {
+        width: 8.5rem;
+        height: 8.5rem;
+    }
+}
+
+@media (min-width: 1024px) {
+    .profile-image-frame {
+        width: 9.5rem;
+        height: 9.5rem;
+    }
 }
 
 .site-header {


### PR DESCRIPTION
## Summary
- update the hero badge copy to highlight Tomas Perticaro by name
- adjust the profile image frame sizing for larger viewports and ensure the photo stays properly cropped on desktop

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dedd8f3844832cb508b02322480854