### PR TITLE
Actualiza textos e íconos del portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@
                 <div class="about-content mt-16 grid gap-10 md:grid-cols-2">
                     <div class="about-card scroll-animate flex flex-col gap-8 rounded-3xl border border-white/10 bg-slate-900/70 p-8 shadow-soft backdrop-blur">
                         <p class="about-description text-lg text-slate-300">
-                            Actualmente estudio IT con foco en Cloud Computing y DevOps. He desarrollado proyectos académicos aplicando infraestructura como código, contenedores y despliegues automatizados.
+                            Actualmente estudio IT, implementando herramientas Cloud y DevOps. He desarrollado proyectos académicos aplicando infraestructura como código, contenedores y despliegues automatizados.
                         </p>
                         <div class="about-highlights grid gap-4">
                             <div class="highlight-item">
@@ -201,7 +201,7 @@
                                 <div class="timeline-dot"></div>
                                 <div class="timeline-content">
                                     <h3>Bootcamp Blockstellart Cloud Computing &amp; DevOps</h3>
-                                    <p>Formación intensiva con proyectos prácticos. Módulos: Introducción a Cloud Computing, Infraestructura global de AWS, Docker y Kubernetes, CI/CD y monitoreo.</p>
+                                    <p>Formación práctica abarcando AWS, Docker, Kubernetes, CI/CD, fundamentos de IA/ML y monitoreo.</p>
                                 </div>
                             </div>
                         </div>
@@ -319,17 +319,17 @@
                 <div class="certifications-grid mt-16 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
                     <div class="certification-card scroll-animate rounded-3xl border border-white/10 bg-slate-900/70 p-8 shadow-soft transition-all duration-300 hover:-translate-y-2 hover:border-accent/60 hover:shadow-glow">
                         <div class="certification-icon mb-6 flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-r from-brand-500 via-accent to-emerald-400 text-2xl text-white shadow-soft">
-                            <i class="fas fa-certificate"></i>
+                            <i class="fas fa-laptop-code"></i>
                         </div>
                         <div class="certification-body space-y-3">
                             <h3 class="text-xl font-semibold text-white">Bootcamp Blockstellart Cloud Computing &amp; DevOps</h3>
                             <span class="certification-issuer text-sm font-semibold uppercase tracking-widest text-accent">Blockstellart</span>
-                            <p class="text-sm text-slate-300">Formación intensiva en Cloud Computing y DevOps. Módulos: Introducción a Cloud Computing, AWS, Docker, Kubernetes, CI/CD y monitoreo.</p>
+                            <p class="text-sm text-slate-300">Formación en AWS, Docker, Kubernetes, CI/CD, fundamentos de IA/ML y monitoreo.</p>
                         </div>
                     </div>
                     <div class="certification-card scroll-animate rounded-3xl border border-white/10 bg-slate-900/70 p-8 shadow-soft transition-all duration-300 hover:-translate-y-2 hover:border-accent/60 hover:shadow-glow">
                         <div class="certification-icon mb-6 flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-r from-brand-500 via-accent to-emerald-400 text-2xl text-white shadow-soft">
-                            <i class="fas fa-certificate"></i>
+                            <i class="fab fa-aws"></i>
                         </div>
                         <div class="certification-body space-y-3">
                             <h3 class="text-xl font-semibold text-white">AWS Certified Cloud Practitioner</h3>
@@ -401,7 +401,7 @@
                             </div>
                             <div class="col-12">
                                 <label for="email" class="form-label text-sm uppercase tracking-widest text-slate-400">Email</label>
-                                <input type="email" id="email" name="email" class="form-control rounded-2xl border-white/10 bg-slate-900/80 py-3 text-slate-100 focus:border-accent focus:bg-slate-900 focus:shadow-glow" placeholder="tu@email.com" required>
+                                <input type="email" id="email" name="email" class="form-control rounded-2xl border-white/10 bg-slate-900/80 py-3 text-slate-100 focus:border-accent focus:bg-slate-900 focus:shadow-glow" placeholder="tu@gmail.com" required>
                             </div>
                             <div class="col-12">
                                 <label for="message" class="form-label text-sm uppercase tracking-widest text-slate-400">Mensaje</label>

--- a/script.js
+++ b/script.js
@@ -82,9 +82,7 @@ function createProjectCard(project) {
         }
     });
 
-    const tagsMarkup = project.tags
-        ? project.tags.map(tag => `<span class="project-tag rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-200">${tag}</span>`).join('')
-        : '';
+    const tagsMarkup = '';
 
     card.innerHTML = `
         <div class="relative overflow-hidden rounded-2xl border border-white/10">
@@ -94,7 +92,7 @@ function createProjectCard(project) {
         <div class="project-info flex flex-col gap-4">
             <h3 class="text-lg font-semibold text-white">${project.title}</h3>
             <p class="project-description text-sm text-slate-300">${project.description}</p>
-            <div class="project-tags flex flex-wrap gap-2">${tagsMarkup}</div>
+            ${tagsMarkup}
         </div>
     `;
 

--- a/style.css
+++ b/style.css
@@ -350,16 +350,14 @@ body {
 
 .experience-timeline .timeline-item {
     position: relative;
-    display: flex;
-    gap: 1.25rem;
-    align-items: flex-start;
+    padding-left: 2.75rem;
 }
 
 .experience-timeline .timeline-item::before {
     content: "";
     position: absolute;
-    left: 0.75rem;
-    top: 1.25rem;
+    left: 1.1rem;
+    top: 1.5rem;
     bottom: -1.5rem;
     width: 2px;
     background: linear-gradient(180deg, rgba(37, 99, 235, 0.6), transparent);
@@ -370,13 +368,21 @@ body {
 }
 
 .timeline-dot {
-    position: relative;
+    position: absolute;
+    left: 0.5rem;
+    top: 0.45rem;
     width: 1.25rem;
     height: 1.25rem;
     border-radius: 999px;
     background: rgba(59, 130, 246, 0.3);
     border: 2px solid rgba(6, 182, 212, 0.6);
     box-shadow: 0 0 0 6px rgba(37, 99, 235, 0.15);
+}
+
+.timeline-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
 }
 
 .timeline-content h3 {
@@ -412,6 +418,24 @@ body {
 .scroll-indicator:hover {
     transform: translate(-50%, -6px);
     background: rgba(37, 99, 235, 0.55);
+}
+
+.contact-form .form-control::placeholder {
+    color: rgba(6, 182, 212, 0.8);
+    opacity: 1;
+}
+
+.contact-form .form-control::-ms-input-placeholder {
+    color: rgba(6, 182, 212, 0.8);
+}
+
+.contact-form .form-control::-moz-placeholder {
+    color: rgba(6, 182, 212, 0.8);
+    opacity: 1;
+}
+
+.contact-form .form-control::-webkit-input-placeholder {
+    color: rgba(6, 182, 212, 0.8);
 }
 
 .scroll-animate {


### PR DESCRIPTION
## Summary
- Ajusta descripciones en las secciones Sobre mí y Cursos y certificaciones para reflejar el nuevo enfoque de estudio.
- Reemplaza íconos en los logros de AWS y el bootcamp, y elimina las etiquetas de dificultad de las tarjetas de proyectos.
- Mejora la UI del timeline y del formulario de contacto con alineación de viñetas y placeholders en color celeste.

## Testing
- No automated tests were run (static site).


------
https://chatgpt.com/codex/tasks/task_e_68df11c39d38832c83bba19f9df08074