### PR TITLE
Show project tech stacks in carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,9 @@
     <meta name="description" content="Portfolio profesional de Tomas Perticaro, estudiante de IT especializado en Cloud Computing y DevOps.">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/devicons/devicon@2.15.1/devicon.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
@@ -359,7 +361,20 @@
                     <p class="section-subtitle">Explora algunos proyectos donde puse en práctica conceptos de infraestructura, automatización y desarrollo cloud.</p>
                 </div>
 
-                <div class="projects-grid mt-16 grid gap-8 md:grid-cols-2 xl:grid-cols-3" id="projectsGrid" aria-live="polite"></div>
+                <div class="projects-slider relative mt-16">
+                    <div class="projects-swiper swiper relative overflow-visible pb-16">
+                        <div class="swiper-wrapper" id="projectsGrid" aria-live="polite"></div>
+
+                        <button class="projects-button-prev swiper-button-prev pointer-events-none opacity-0 hidden lg:flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-slate-900/80 text-lg text-slate-100 shadow-soft transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-accent/70 absolute -left-6 top-1/2 -translate-y-1/2" type="button" aria-label="Proyecto anterior">
+                            <i class="fas fa-arrow-left"></i>
+                        </button>
+                        <button class="projects-button-next swiper-button-next pointer-events-none opacity-0 hidden lg:flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-slate-900/80 text-lg text-slate-100 shadow-soft transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-accent/70 absolute -right-6 top-1/2 -translate-y-1/2" type="button" aria-label="Proyecto siguiente">
+                            <i class="fas fa-arrow-right"></i>
+                        </button>
+
+                        <div class="projects-pagination swiper-pagination !bottom-0"></div>
+                    </div>
+                </div>
             </div>
         </section>
 
@@ -522,6 +537,7 @@
         document.getElementById('currentYear').textContent = new Date().getFullYear();
     </script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
     <script src="projects-config.js"></script>
     <script src="script.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -437,6 +437,110 @@ body {
     transform: translateY(24px);
 }
 
+.project-stack-wrapper {
+    position: relative;
+    background: radial-gradient(circle at 12% 0%, rgba(37, 99, 235, 0.22), rgba(15, 23, 42, 0.92));
+    box-shadow: inset 0 0 45px rgba(15, 23, 42, 0.45);
+}
+
+.project-stack-wrapper::before {
+    content: "";
+    position: absolute;
+    inset: -40%;
+    background: radial-gradient(circle, rgba(6, 182, 212, 0.22) 0%, transparent 70%);
+    opacity: 0.45;
+    transition: opacity 0.5s ease;
+}
+
+.project-card:hover .project-stack-wrapper::before,
+.project-card:focus-visible .project-stack-wrapper::before {
+    opacity: 0.7;
+}
+
+.project-card:hover .project-stack-wrapper,
+.project-card:focus-visible .project-stack-wrapper {
+    border-color: rgba(6, 182, 212, 0.55);
+}
+
+.project-stack-grid {
+    position: relative;
+    z-index: 1;
+}
+
+.tech-pill {
+    backdrop-filter: blur(12px);
+    background: linear-gradient(145deg, rgba(30, 41, 59, 0.82), rgba(15, 23, 42, 0.88));
+    border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.tech-pill:hover,
+.tech-pill:focus-visible {
+    border-color: rgba(6, 182, 212, 0.6);
+}
+
+.tech-icon {
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0.65));
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.16);
+}
+
+.tech-icon i {
+    font-size: 1.85rem;
+    line-height: 1;
+}
+
+.tech-icon-initial {
+    font-size: 1.1rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.95);
+}
+
+.tech-pill-label {
+    color: rgba(226, 232, 240, 0.9);
+}
+
+.projects-swiper .swiper-slide {
+    height: auto;
+}
+
+.projects-swiper .swiper-pagination {
+    position: static;
+    margin-top: 2rem;
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+}
+
+.projects-swiper .swiper-pagination-bullet {
+    width: 12px;
+    height: 12px;
+    background: rgba(148, 163, 184, 0.45);
+    opacity: 1;
+    transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.projects-swiper .swiper-pagination-bullet-active {
+    background: linear-gradient(135deg, #2563eb, #06b6d4);
+    transform: scale(1.2);
+    box-shadow: 0 0 15px rgba(6, 182, 212, 0.35);
+}
+
+.projects-button-prev,
+.projects-button-next {
+    box-shadow: 0 18px 40px -20px rgba(14, 165, 233, 0.55);
+}
+
+.projects-button-prev:hover,
+.projects-button-next:hover {
+    box-shadow: 0 22px 55px -25px rgba(6, 182, 212, 0.65);
+}
+
+.projects-button-prev::after,
+.projects-button-next::after {
+    display: none;
+}
+
 .project-tag {
     color: rgba(203, 213, 225, 0.85);
     background: rgba(148, 163, 184, 0.12);


### PR DESCRIPTION
## Summary
- replace the project carousel thumbnail image with a technology stack grid built from the configuration file
- include devicon icons and tailored markup so each slide highlights the tools used in that project
- refresh the custom styles to support the badge layout, gradients, and hover states around the new stack view

## Testing
- python3 -m http.server 8000 (visual verification)


------
https://chatgpt.com/codex/tasks/task_e_68df1ceff218832cb6f1d8ac9fa8e14f