### PR TITLE
Remove project carousel arrows

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,13 +365,6 @@
                     <div class="projects-swiper swiper relative overflow-visible pb-16">
                         <div class="swiper-wrapper" id="projectsGrid" aria-live="polite"></div>
 
-                        <button class="projects-button-prev swiper-button-prev pointer-events-none opacity-0 hidden lg:flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-slate-900/80 text-lg text-slate-100 shadow-soft transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-accent/70 absolute -left-6 top-1/2 -translate-y-1/2" type="button" aria-label="Proyecto anterior">
-                            <i class="fas fa-arrow-left"></i>
-                        </button>
-                        <button class="projects-button-next swiper-button-next pointer-events-none opacity-0 hidden lg:flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-slate-900/80 text-lg text-slate-100 shadow-soft transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-accent/70 absolute -right-6 top-1/2 -translate-y-1/2" type="button" aria-label="Proyecto siguiente">
-                            <i class="fas fa-arrow-right"></i>
-                        </button>
-
                         <div class="projects-pagination swiper-pagination !bottom-0"></div>
                     </div>
                 </div>

--- a/script.js
+++ b/script.js
@@ -210,19 +210,6 @@ function initializeProjectsSwiper(totalSlides) {
         pagination: {
             el: '.projects-pagination',
             clickable: true
-        },
-        navigation: {
-            nextEl: '.projects-button-next',
-            prevEl: '.projects-button-prev'
-        }
-    });
-
-    const navButtons = document.querySelectorAll('.projects-button-prev, .projects-button-next');
-    navButtons.forEach(button => {
-        if (shouldLoop) {
-            button.classList.remove('pointer-events-none', 'opacity-0');
-        } else {
-            button.classList.add('pointer-events-none', 'opacity-0');
         }
     });
 }


### PR DESCRIPTION
## Summary
- remove the previous/next arrow buttons from the projects carousel markup
- simplify the Swiper initialization so only the pagination bullets remain active

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e00b849808832c9a12cff059918558