### PR TITLE
Replace project artwork with contextual icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/devicons/devicon@2.15.1/devicon.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
@@ -361,12 +360,8 @@
                     <p class="section-subtitle">Explora algunos proyectos donde puse en práctica conceptos de infraestructura, automatización y desarrollo cloud.</p>
                 </div>
 
-                <div class="projects-slider relative mt-16">
-                    <div class="projects-swiper swiper relative overflow-visible pb-16">
-                        <div class="swiper-wrapper" id="projectsGrid" aria-live="polite"></div>
-
-                        <div class="projects-pagination swiper-pagination !bottom-0"></div>
-                    </div>
+                <div class="projects-grid-layout relative mt-16">
+                    <div class="projects-grid" id="projectsGrid" aria-live="polite"></div>
                 </div>
             </div>
         </section>
@@ -515,8 +510,12 @@
                 <span class="modal-close inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border border-white/10 bg-slate-900/70 text-2xl text-slate-400 transition-all duration-300 hover:scale-105 hover:text-white" role="button" aria-label="Cerrar">&times;</span>
             </div>
             <div class="modal-body grid gap-6 bg-slate-900/90 px-6 py-6 md:grid-cols-[1fr,1.2fr]">
-                <div class="modal-image-container overflow-hidden rounded-2xl border border-white/10">
-                    <img id="modalImage" src="" alt="" class="modal-image h-full w-full object-cover">
+                <div class="modal-visual-container overflow-hidden rounded-2xl border border-white/10">
+                    <div class="modal-icon-wrapper">
+                        <div id="modalIcon" class="modal-icon">
+                            <i class="fa-solid fa-diagram-project" aria-hidden="true"></i>
+                        </div>
+                    </div>
                 </div>
                 <div class="modal-info flex flex-col gap-4">
                     <p id="modalDescription" class="text-sm text-slate-300"></p>
@@ -530,7 +529,6 @@
         document.getElementById('currentYear').textContent = new Date().getFullYear();
     </script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
     <script src="projects-config.js"></script>
     <script src="script.js"></script>
 </body>

--- a/projects-config.js
+++ b/projects-config.js
@@ -8,36 +8,40 @@ const projects = [
         title: "Aplicación Web con Angular desplegada en AWS",
         description: "Muestra cómo servir sitios web estáticos o SPA en la nube",
         fullDescription: "Sitio web estático Angular alojado en Amazon S3, distribuido globalmente con CloudFront y protegido con HTTPS mediante AWS Certificate Manager.",
-        image: "imagenes/App_Web_Desplegada_AWS.jpg",
         technologies: ["Angular", "Amazon S3", "CloudFront", "Route 53", "Certificate Manager"],
-        tags: ["Básico"]
+        iconClass: "fa-solid fa-cloud-arrow-up",
+        iconBackground: "linear-gradient(135deg, rgba(37, 99, 235, 0.85), rgba(6, 182, 212, 0.75))",
+        iconColor: "rgba(224, 242, 254, 0.95)"
     },
     {
         id: 2,
         title: "Proyecto de Tenis - Sistema de Socios",
         description: "Aplicación para gestión de socios de un club de tenis, desplegada en Kubernetes",
         fullDescription: "Capstone project: Desarrollo de una aplicación para administrar socios de un club de tenis. El backend se empaquetó en Docker, se publicó en DockerHub y se desplegó en un clúster de Kubernetes con Minikube. Incluye manifiestos de Kubernetes (Deployment, Service, Namespace) y un pipeline de despliegue manual.",
-        image: "imagenes/Seguimiento_Ubicacion.jpg",
         technologies: ["Docker", "Kubernetes", "Minikube", "YAML", "Node.js"],
-        tags: ["Avanzado"]
+        iconClass: "fa-solid fa-table-tennis-paddle-ball",
+        iconBackground: "linear-gradient(135deg, rgba(124, 58, 237, 0.8), rgba(236, 72, 153, 0.65))",
+        iconColor: "rgba(250, 250, 255, 0.95)"
     },
     {
         id: 3,
         title: "Docker en AWS",
         description: "Contenedores Docker desplegados en la nube con servicios de AWS",
         fullDescription: "Aplicación dockerizada desplegada en servicios de AWS. Incluye integración con Amazon ECR para imágenes, y despliegue gestionado con servicios en la nube.",
-        image: "imagenes/Terraform_AWS.jpg",
         technologies: ["Docker", "Amazon ECR", "EC2", "VPC"],
-        tags: ["Avanzado"]
+        iconClass: "fa-brands fa-docker",
+        iconBackground: "linear-gradient(135deg, rgba(14, 165, 233, 0.85), rgba(59, 130, 246, 0.75))",
+        iconColor: "rgba(224, 242, 254, 0.95)"
     },
     {
         id: 4,
         title: "Kubernetes en AWS",
         description: "CI/CD, despliegue con contenedores y uso de múltiples lenguajes y tecnologías",
         fullDescription: "Aplicación distribuida en clúster de Kubernetes gestionado con múltiples APIs backend en contenedores, base de datos MongoDB y servicios de AWS.",
-        image: "imagenes/Kubernetes_AWS.jpg",
         technologies: ["Angular", "Docker", "Amazon ECR", "MongoDB", "Amazon SES", "Minikube"],
-        tags: ["Profesional"]
+        iconClass: "fa-solid fa-diagram-project",
+        iconBackground: "linear-gradient(135deg, rgba(5, 150, 105, 0.82), rgba(34, 197, 94, 0.65))",
+        iconColor: "rgba(236, 253, 245, 0.95)"
     }
 ];
 

--- a/script.js
+++ b/script.js
@@ -9,7 +9,6 @@
 // DOM Elements
 let projectsGrid, modal, modalClose, filterBtns, contactForm, particlesContainer;
 let nav, navMenu, navToggle;
-let projectsSwiper;
 
 // Initialize DOM elements when document is ready
 function initializeDOMElements() {
@@ -28,21 +27,21 @@ function initializeDOMElements() {
 let currentFilter = 'all';
 
 const TECHNOLOGY_ICON_MAP = {
-    'Angular': 'devicon-angularjs-plain colored',
-    'Amazon S3': 'devicon-amazonwebservices-plain colored',
-    'CloudFront': 'devicon-amazonwebservices-plain colored',
-    'Route 53': 'devicon-amazonwebservices-plain colored',
-    'Certificate Manager': 'fas fa-certificate text-amber-300',
-    'Docker': 'devicon-docker-plain colored',
-    'Kubernetes': 'devicon-kubernetes-plain colored',
-    'Minikube': 'devicon-kubernetes-plain colored',
-    'YAML': 'devicon-yaml-plain colored',
-    'Node.js': 'devicon-nodejs-plain colored',
-    'Amazon ECR': 'devicon-amazonwebservices-plain colored',
-    'EC2': 'devicon-amazonwebservices-plain colored',
-    'VPC': 'devicon-amazonwebservices-plain colored',
-    'MongoDB': 'devicon-mongodb-plain colored',
-    'Amazon SES': 'devicon-amazonwebservices-plain colored'
+    'Angular': 'fa-brands fa-angular',
+    'Amazon S3': 'fa-solid fa-database',
+    'CloudFront': 'fa-solid fa-globe',
+    'Route 53': 'fa-solid fa-route',
+    'Certificate Manager': 'fa-solid fa-shield-halved',
+    'Docker': 'fa-brands fa-docker',
+    'Kubernetes': 'fa-solid fa-network-wired',
+    'Minikube': 'fa-solid fa-cubes',
+    'YAML': 'fa-solid fa-code',
+    'Node.js': 'fa-brands fa-node-js',
+    'Amazon ECR': 'fa-solid fa-layer-group',
+    'EC2': 'fa-solid fa-server',
+    'VPC': 'fa-solid fa-diagram-project',
+    'MongoDB': 'fa-solid fa-leaf',
+    'Amazon SES': 'fa-solid fa-envelope-open-text'
 };
 
 // Initialize the application
@@ -72,17 +71,13 @@ function loadProjects(filter = 'all') {
 
     const filteredProjects = filter === 'all'
         ? projects
-        : projects.filter(project => project.tags.includes(filter));
+        : projects.filter(project => Array.isArray(project.tags) && project.tags.includes(filter));
 
     console.log('Filtered projects:', filteredProjects.length);
 
     filteredProjects.forEach((project, index) => {
-        const projectSlide = createProjectSlide(project, index);
-        projectsGrid.appendChild(projectSlide);
-    });
-
-    requestAnimationFrame(() => {
-        initializeProjectsSwiper(filteredProjects.length);
+        const projectCard = createProjectCard(project, index);
+        projectsGrid.appendChild(projectCard);
     });
 
     // Trigger animation
@@ -97,7 +92,20 @@ function createTechnologyBadges(technologies = []) {
         return '';
     }
 
-    return technologies.map(tech => createTechnologyBadge(tech)).join('');
+    const displayTechnologies = technologies.slice(0, 4);
+    let badgesMarkup = displayTechnologies.map(tech => createTechnologyBadge(tech)).join('');
+
+    const remainingCount = technologies.length - displayTechnologies.length;
+    if (remainingCount > 0) {
+        badgesMarkup += `
+            <div class="tech-pill tech-pill-more" aria-label="${remainingCount} tecnologías adicionales">
+                <span class="tech-icon" aria-hidden="true">+${remainingCount}</span>
+                <span class="tech-pill-label">más</span>
+            </div>
+        `;
+    }
+
+    return badgesMarkup;
 }
 
 function createTechnologyBadge(tech) {
@@ -107,11 +115,11 @@ function createTechnologyBadge(tech) {
         : `<span class="tech-icon-initial" aria-hidden="true">${getTechnologyInitials(tech)}</span>`;
 
     return `
-        <div class="tech-pill group/tech flex items-center gap-3 rounded-2xl border border-white/10 bg-slate-950/80 p-4 text-left shadow-[0_22px_44px_-32px_rgba(14,165,233,0.75)] transition-all duration-500 hover:-translate-y-1 hover:border-accent/50 hover:shadow-glow">
-            <span class="tech-icon flex h-12 w-12 items-center justify-center rounded-xl bg-slate-900/80 shadow-inner transition-transform duration-500 group-hover/tech:scale-110">
+        <div class="tech-pill group/tech">
+            <span class="tech-icon" aria-hidden="true">
                 ${iconMarkup}
             </span>
-            <span class="tech-pill-label text-sm font-semibold tracking-wide text-slate-200">${tech}</span>
+            <span class="tech-pill-label">${tech}</span>
         </div>
     `;
 }
@@ -130,11 +138,8 @@ function getTechnologyInitials(tech) {
     return initials.join('').toUpperCase();
 }
 
-// Create project slide element
-function createProjectSlide(project, index) {
-    const slide = document.createElement('div');
-    slide.className = 'swiper-slide h-auto';
-
+// Create project card element
+function createProjectCard(project, index) {
     const card = document.createElement('article');
     card.className = 'project-card group flex h-full cursor-pointer flex-col gap-6 overflow-hidden rounded-3xl border border-white/10 bg-slate-900/70 p-6 shadow-soft transition-all duration-500 hover:-translate-y-2 hover:border-accent/60 hover:shadow-glow focus:outline-none focus:ring-2 focus:ring-accent/70';
     card.setAttribute('tabindex', '0');
@@ -148,70 +153,42 @@ function createProjectSlide(project, index) {
     });
 
     const badgesMarkup = createTechnologyBadges(project.technologies);
+    const iconClass = project.iconClass || 'fa-solid fa-diagram-project';
+    const iconStyles = [];
+
+    if (project.iconBackground) {
+        iconStyles.push(`background: ${project.iconBackground}`);
+    }
+
+    if (project.iconColor) {
+        iconStyles.push(`color: ${project.iconColor}`);
+    }
+
+    const iconStyleAttribute = iconStyles.length > 0
+        ? ` style="${iconStyles.join('; ')}"`
+        : '';
 
     card.innerHTML = `
-        <div class="project-stack-wrapper relative flex h-64 w-full items-center justify-center overflow-hidden rounded-2xl border border-white/10 bg-slate-950/80 p-6">
-            <div class="stack-badge absolute left-6 top-6 z-20 inline-flex items-center gap-2 rounded-full border border-white/10 bg-slate-900/70 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.32em] text-slate-200/80">
-                <span class="block h-1 w-1 rounded-full bg-accent/80"></span>
-                Stack principal
+        <div class="project-media relative overflow-hidden rounded-2xl border border-white/10">
+            <div class="project-media-overlay"></div>
+            <div class="project-icon-wrapper">
+                <div class="project-icon"${iconStyleAttribute}>
+                    <i class="${iconClass}" aria-hidden="true"></i>
+                </div>
             </div>
-            <div class="project-stack-grid relative z-10 grid w-full grid-cols-2 gap-4 sm:grid-cols-3 xl:grid-cols-4">
+        </div>
+        <div class="project-content flex flex-1 flex-col gap-4">
+            <div>
+                <h3 class="project-title text-xl font-semibold text-white">${project.title}</h3>
+                <p class="project-description text-base text-slate-300">${project.description}</p>
+            </div>
+            <div class="project-technologies">
                 ${badgesMarkup}
             </div>
         </div>
-        <div class="project-info flex flex-1 flex-col gap-4">
-            <h3 class="text-xl font-semibold text-white">${project.title}</h3>
-            <p class="project-description text-base text-slate-300">${project.description}</p>
-        </div>
     `;
 
-    slide.appendChild(card);
-    return slide;
-}
-
-function initializeProjectsSwiper(totalSlides) {
-    const swiperContainer = document.querySelector('.projects-swiper');
-    if (!swiperContainer) return;
-
-    if (projectsSwiper) {
-        projectsSwiper.destroy(true, true);
-        projectsSwiper = null;
-    }
-
-    if (totalSlides === 0) {
-        return;
-    }
-
-    const shouldLoop = totalSlides > 1;
-
-    projectsSwiper = new Swiper('.projects-swiper', {
-        slidesPerView: 1,
-        spaceBetween: 24,
-        loop: shouldLoop,
-        speed: 600,
-        grabCursor: true,
-        centeredSlides: totalSlides === 1,
-        keyboard: {
-            enabled: true,
-            onlyInViewport: true
-        },
-        observer: true,
-        observeParents: true,
-        breakpoints: {
-            768: {
-                slidesPerView: Math.min(2, totalSlides),
-                spaceBetween: 28
-            },
-            1280: {
-                slidesPerView: Math.min(3, totalSlides),
-                spaceBetween: 32
-            }
-        },
-        pagination: {
-            el: '.projects-pagination',
-            clickable: true
-        }
-    });
+    return card;
 }
 
 // Project filter functionality
@@ -265,14 +242,34 @@ function initializeModal() {
 // Open project modal
 function openModal(project) {
     const modalTitle = document.getElementById('modalTitle');
-    const modalImage = document.getElementById('modalImage');
+    const modalIcon = document.getElementById('modalIcon');
     const modalDescription = document.getElementById('modalDescription');
     const modalTechnologies = document.getElementById('modalTechnologies');
 
     modalTitle.textContent = project.title;
-    modalImage.src = project.image;
-    modalImage.alt = project.title;
     modalDescription.textContent = project.fullDescription;
+
+    if (modalIcon) {
+        const iconClass = project.iconClass || 'fa-solid fa-diagram-project';
+        const iconStyles = [];
+
+        if (project.iconBackground) {
+            iconStyles.push(`background: ${project.iconBackground}`);
+        }
+
+        if (project.iconColor) {
+            iconStyles.push(`color: ${project.iconColor}`);
+        }
+
+        modalIcon.className = `modal-icon`;
+        if (iconStyles.length > 0) {
+            modalIcon.setAttribute('style', iconStyles.join('; '));
+        } else {
+            modalIcon.removeAttribute('style');
+        }
+
+        modalIcon.innerHTML = `<i class="${iconClass}" aria-hidden="true"></i>`;
+    }
 
     modalTechnologies.innerHTML = project.technologies.map(tech =>
         `<span class="modal-tech-tag">${tech}</span>`

--- a/style.css
+++ b/style.css
@@ -13,6 +13,7 @@ html {
 body {
     background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), rgba(15, 23, 42, 0.9));
     min-height: 100vh;
+    overflow-x: hidden;
 }
 
 .profile-image-frame {
@@ -437,59 +438,183 @@ body {
     transform: translateY(24px);
 }
 
-.project-stack-wrapper {
-    position: relative;
-    background: radial-gradient(circle at 12% 0%, rgba(37, 99, 235, 0.22), rgba(15, 23, 42, 0.92));
-    box-shadow: inset 0 0 45px rgba(15, 23, 42, 0.45);
-}
-
-.project-stack-wrapper::before {
+.projects-grid-layout::before {
     content: "";
     position: absolute;
-    inset: -40%;
-    background: radial-gradient(circle, rgba(6, 182, 212, 0.22) 0%, transparent 70%);
-    opacity: 0.45;
+    inset: -10% 5% auto;
+    height: 60%;
+    background: radial-gradient(circle, rgba(37, 99, 235, 0.16), transparent 60%);
+    pointer-events: none;
+}
+
+.projects-grid-layout {
+    position: relative;
+}
+
+.projects-grid {
+    position: relative;
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+@media (min-width: 768px) {
+    .projects-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 2.5rem;
+    }
+}
+
+@media (min-width: 1280px) {
+    .projects-grid {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+}
+
+.project-card {
+    background: linear-gradient(160deg, rgba(15, 23, 42, 0.86), rgba(15, 23, 42, 0.72));
+    border: 1px solid rgba(148, 163, 184, 0.14);
+    box-shadow: 0 30px 80px -50px rgba(14, 165, 233, 0.55);
+    transition: transform 0.5s ease, border-color 0.4s ease, box-shadow 0.4s ease;
+}
+
+.project-card:hover,
+.project-card:focus-visible {
+    border-color: rgba(6, 182, 212, 0.55);
+    box-shadow: 0 45px 95px -55px rgba(14, 165, 233, 0.65);
+}
+
+.project-media {
+    position: relative;
+    overflow: hidden;
+    height: 200px;
+    border-radius: 1.5rem;
+    background: radial-gradient(circle at 25% 25%, rgba(56, 189, 248, 0.28), rgba(15, 23, 42, 0.85));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+}
+
+.modal-visual-container {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 220px;
+    background: radial-gradient(circle at 30% 25%, rgba(56, 189, 248, 0.2), rgba(15, 23, 42, 0.88));
+    padding: 2.5rem;
+}
+
+.project-media-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(145deg, rgba(15, 23, 42, 0.15), rgba(6, 182, 212, 0.35));
+    opacity: 0;
+    z-index: 0;
     transition: opacity 0.5s ease;
 }
 
-.project-card:hover .project-stack-wrapper::before,
-.project-card:focus-visible .project-stack-wrapper::before {
-    opacity: 0.7;
+.project-card:hover .project-media-overlay,
+.project-card:focus-visible .project-media-overlay {
+    opacity: 1;
 }
 
-.project-card:hover .project-stack-wrapper,
-.project-card:focus-visible .project-stack-wrapper {
-    border-color: rgba(6, 182, 212, 0.55);
-}
-
-.project-stack-grid {
+.project-icon-wrapper,
+.modal-icon-wrapper {
     position: relative;
     z-index: 1;
+    display: flex;
+    width: 100%;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+}
+
+.project-icon,
+.modal-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 6rem;
+    height: 6rem;
+    border-radius: 1.75rem;
+    background: linear-gradient(135deg, rgba(148, 163, 184, 0.22), rgba(30, 41, 59, 0.88));
+    box-shadow: 0 32px 65px -40px rgba(14, 165, 233, 0.75), inset 0 0 0 1px rgba(148, 163, 184, 0.28);
+    color: rgba(226, 232, 240, 0.95);
+    font-size: 2.75rem;
+    transition: transform 0.5s ease, box-shadow 0.5s ease;
+}
+
+.modal-icon {
+    width: 7rem;
+    height: 7rem;
+    font-size: 3.1rem;
+}
+
+.project-icon i,
+.modal-icon i {
+    line-height: 1;
+}
+
+.project-card:hover .project-icon,
+.project-card:focus-visible .project-icon {
+    transform: translateY(-4px) scale(1.02);
+    box-shadow: 0 42px 85px -45px rgba(14, 165, 233, 0.85), inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+}
+
+.project-technologies {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+    gap: 1rem;
 }
 
 .tech-pill {
-    backdrop-filter: blur(12px);
-    background: linear-gradient(145deg, rgba(30, 41, 59, 0.82), rgba(15, 23, 42, 0.88));
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.95rem 1rem;
+    border-radius: 1.25rem;
     border: 1px solid rgba(148, 163, 184, 0.18);
+    background: linear-gradient(150deg, rgba(30, 41, 59, 0.82), rgba(15, 23, 42, 0.88));
+    backdrop-filter: blur(8px);
+    transition: transform 0.4s ease, border-color 0.4s ease, box-shadow 0.4s ease;
+    text-align: center;
 }
 
 .tech-pill:hover,
 .tech-pill:focus-visible {
-    border-color: rgba(6, 182, 212, 0.6);
+    transform: translateY(-4px);
+    border-color: rgba(6, 182, 212, 0.5);
+    box-shadow: 0 20px 45px -28px rgba(14, 165, 233, 0.75);
 }
 
 .tech-icon {
-    background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0.65));
-    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.16);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 3.25rem;
+    height: 3.25rem;
+    border-radius: 999px;
+    background: radial-gradient(circle at 35% 30%, rgba(56, 189, 248, 0.28), rgba(15, 23, 42, 0.85));
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+    color: rgba(125, 211, 252, 0.95);
+    font-size: 1.45rem;
+    transition: transform 0.4s ease;
+}
+
+.group\/tech:hover .tech-icon,
+.group\/tech:focus-visible .tech-icon {
+    transform: scale(1.08);
 }
 
 .tech-icon i {
-    font-size: 1.85rem;
     line-height: 1;
 }
 
 .tech-icon-initial {
-    font-size: 1.1rem;
+    font-size: 1.05rem;
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -497,49 +622,23 @@ body {
 }
 
 .tech-pill-label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
     color: rgba(226, 232, 240, 0.9);
 }
 
-.projects-swiper .swiper-slide {
-    height: auto;
+.tech-pill-more .tech-icon {
+    background: rgba(6, 182, 212, 0.2);
+    color: rgba(6, 182, 212, 0.95);
+    font-weight: 700;
+    font-size: 1.1rem;
 }
 
-.projects-swiper .swiper-pagination {
-    position: static;
-    margin-top: 2rem;
-    display: flex;
-    justify-content: center;
-    gap: 0.75rem;
+.tech-pill-more .tech-pill-label {
+    color: rgba(148, 163, 184, 0.95);
 }
 
-.projects-swiper .swiper-pagination-bullet {
-    width: 12px;
-    height: 12px;
-    background: rgba(148, 163, 184, 0.45);
-    opacity: 1;
-    transition: background 0.3s ease, transform 0.3s ease;
-}
-
-.projects-swiper .swiper-pagination-bullet-active {
-    background: linear-gradient(135deg, #2563eb, #06b6d4);
-    transform: scale(1.2);
-    box-shadow: 0 0 15px rgba(6, 182, 212, 0.35);
-}
-
-.projects-button-prev,
-.projects-button-next {
-    box-shadow: 0 18px 40px -20px rgba(14, 165, 233, 0.55);
-}
-
-.projects-button-prev:hover,
-.projects-button-next:hover {
-    box-shadow: 0 22px 55px -25px rgba(6, 182, 212, 0.65);
-}
-
-.projects-button-prev::after,
-.projects-button-next::after {
-    display: none;
-}
 
 .project-tag {
     color: rgba(203, 213, 225, 0.85);


### PR DESCRIPTION
## Summary
- replace the projects carousel with a responsive grid that displays all four cards at once
- refresh the project card design with icon-driven headers that replace the former imagery and level tags while keeping the Font Awesome technology badges
- remove the Swiper dependency and tighten styling to avoid horizontal scrolling
- mirror the icon-centric presentation inside the project modal for a cohesive experience

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e071b3d09c832ca3a8bcbfd709ba98