### PR TITLE
Actualizar navegación móvil y cuadrícula de proyectos

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,23 +37,18 @@
 </head>
 <body class="font-inter bg-slate-950 text-slate-100">
     <header class="site-header sticky top-0 z-50">
-        <nav class="nav container-xl mx-auto flex items-center justify-between gap-6 rounded-full bg-slate-900/80 px-6 py-4 shadow-soft backdrop-blur" aria-label="Principal">
-            <a href="#hero" class="nav-logo flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-brand-500 via-accent to-emerald-400 text-lg font-semibold text-white shadow-glow transition-transform duration-300 hover:scale-105">TP</a>
-            <div class="nav-menu hidden w-full flex-col items-start gap-4 rounded-2xl border border-white/10 bg-slate-900/95 p-6 text-sm font-medium text-slate-100 shadow-soft transition-all duration-300 lg:flex lg:w-auto lg:flex-1 lg:flex-row lg:items-center lg:justify-end lg:gap-6 lg:rounded-none lg:border-0 lg:bg-transparent lg:p-0 lg:shadow-none" id="navMenu">
-                <a href="#about" class="nav-link nav-link-underline w-full rounded-xl px-4 py-2 transition-all duration-300 hover:bg-white/5 lg:w-auto lg:rounded-full">Sobre mí</a>
-                <a href="#skills" class="nav-link nav-link-underline w-full rounded-xl px-4 py-2 transition-all duration-300 hover:bg-white/5 lg:w-auto lg:rounded-full">Habilidades</a>
-                <a href="#education" class="nav-link nav-link-underline w-full rounded-xl px-4 py-2 transition-all duration-300 hover:bg-white/5 lg:w-auto lg:rounded-full">Educación</a>
-                <a href="#projects" class="nav-link nav-link-underline w-full rounded-xl px-4 py-2 transition-all duration-300 hover:bg-white/5 lg:w-auto lg:rounded-full">Proyectos</a>
-                <a href="#certifications" class="nav-link nav-link-underline w-full rounded-xl px-4 py-2 transition-all duration-300 hover:bg-white/5 lg:w-auto lg:rounded-full">Certificaciones</a>
-                <a href="#contact" class="nav-link nav-link-underline w-full rounded-xl px-4 py-2 transition-all duration-300 hover:bg-white/5 lg:w-auto lg:rounded-full">Contacto</a>
-            </div>
-            <div class="nav-actions flex items-center gap-3">
+        <nav class="nav container-xl mx-auto flex flex-wrap items-center justify-between gap-4 rounded-3xl bg-slate-900/80 px-6 py-4 shadow-soft backdrop-blur lg:flex-nowrap lg:rounded-full" aria-label="Principal">
+            <a href="#hero" class="nav-logo order-1 flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-brand-500 via-accent to-emerald-400 text-lg font-semibold text-white shadow-glow transition-transform duration-300 hover:scale-105">TP</a>
+            <div class="nav-actions order-2 flex w-full items-center justify-center gap-3 lg:order-3 lg:w-auto lg:justify-end">
                 <a href="https://www.linkedin.com/in/tomas-perticaro-517294232" target="_blank" rel="noopener" class="btn btn-secondary btn-sm rounded-full bg-gradient-to-r from-brand-500 to-accent px-4 py-2 text-sm font-semibold text-white shadow-soft transition-transform duration-300 hover:scale-105 hover:shadow-glow">LinkedIn</a>
-                <button class="hamburger inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-white/10 bg-slate-800/80 transition-all duration-300 hover:scale-105 hover:border-accent lg:hidden" id="navToggle" type="button" aria-label="Abrir menú" aria-controls="navMenu" aria-expanded="false">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </button>
+            </div>
+            <div class="nav-menu order-3 flex w-full flex-wrap items-center justify-center gap-2 rounded-2xl border border-white/10 bg-slate-900/90 p-4 text-sm font-medium text-slate-100 shadow-soft transition-all duration-300 lg:order-2 lg:w-auto lg:flex-1 lg:flex-row lg:items-center lg:justify-end lg:gap-6 lg:rounded-none lg:border-0 lg:bg-transparent lg:p-0 lg:shadow-none" id="navMenu">
+                <a href="#about" class="nav-link nav-link-underline w-full rounded-xl px-4 py-2 text-center transition-all duration-300 hover:bg-white/5 sm:w-auto lg:rounded-full lg:text-left">Sobre mí</a>
+                <a href="#skills" class="nav-link nav-link-underline w-full rounded-xl px-4 py-2 text-center transition-all duration-300 hover:bg-white/5 sm:w-auto lg:rounded-full lg:text-left">Habilidades</a>
+                <a href="#education" class="nav-link nav-link-underline w-full rounded-xl px-4 py-2 text-center transition-all duration-300 hover:bg-white/5 sm:w-auto lg:rounded-full lg:text-left">Educación</a>
+                <a href="#projects" class="nav-link nav-link-underline w-full rounded-xl px-4 py-2 text-center transition-all duration-300 hover:bg-white/5 sm:w-auto lg:rounded-full lg:text-left">Proyectos</a>
+                <a href="#certifications" class="nav-link nav-link-underline w-full rounded-xl px-4 py-2 text-center transition-all duration-300 hover:bg-white/5 sm:w-auto lg:rounded-full lg:text-left">Certificaciones</a>
+                <a href="#contact" class="nav-link nav-link-underline w-full rounded-xl px-4 py-2 text-center transition-all duration-300 hover:bg-white/5 sm:w-auto lg:rounded-full lg:text-left">Contacto</a>
             </div>
         </nav>
     </header>

--- a/script.js
+++ b/script.js
@@ -8,7 +8,7 @@
 
 // DOM Elements
 let projectsGrid, modal, modalClose, filterBtns, contactForm, particlesContainer;
-let nav, navMenu, navToggle;
+let nav, navMenu;
 
 // Initialize DOM elements when document is ready
 function initializeDOMElements() {
@@ -20,7 +20,6 @@ function initializeDOMElements() {
     particlesContainer = document.getElementById('particles');
     nav = document.querySelector('.nav');
     navMenu = document.getElementById('navMenu');
-    navToggle = document.getElementById('navToggle');
 }
 
 // Current filter
@@ -450,51 +449,12 @@ function initializeScrollAnimations() {
 function initializeNavigation() {
     if (!nav) return;
 
-    const navLinks = document.querySelectorAll('.nav-link');
-
-    if (navToggle && navMenu) {
-        navToggle.addEventListener('click', () => {
-            const isActive = navMenu.classList.toggle('active');
-            navMenu.classList.toggle('hidden', !isActive);
-            navMenu.classList.toggle('flex', isActive);
-            navToggle.classList.toggle('active', isActive);
-            navToggle.setAttribute('aria-expanded', isActive ? 'true' : 'false');
-        });
-    }
-
-    if (navLinks.length) {
-        navLinks.forEach(link => {
-            link.addEventListener('click', () => {
-                if (navMenu && navMenu.classList.contains('active')) {
-                    navMenu.classList.remove('active');
-                    navMenu.classList.add('hidden');
-                    navMenu.classList.remove('flex');
-                }
-
-                if (navToggle && navToggle.classList.contains('active')) {
-                    navToggle.classList.remove('active');
-                    navToggle.setAttribute('aria-expanded', 'false');
-                }
-            });
-        });
-    }
-
-    window.addEventListener('resize', () => {
-        if (window.innerWidth >= 1024) {
-            if (navMenu) {
-                navMenu.classList.remove('hidden');
-                navMenu.classList.add('flex');
-                navMenu.classList.remove('active');
-            }
-            if (navToggle) {
-                navToggle.classList.remove('active');
-                navToggle.setAttribute('aria-expanded', 'false');
-            }
-        } else if (navMenu && !navMenu.classList.contains('active')) {
-            navMenu.classList.add('hidden');
-            navMenu.classList.remove('flex');
+    if (navMenu) {
+        navMenu.classList.remove('hidden');
+        if (!navMenu.classList.contains('flex')) {
+            navMenu.classList.add('flex');
         }
-    });
+    }
 
     const handleScroll = () => {
         if (window.scrollY > 40) {

--- a/style.css
+++ b/style.css
@@ -467,7 +467,8 @@ body {
 
 @media (min-width: 1280px) {
     .projects-grid {
-        grid-template-columns: repeat(4, minmax(0, 1fr));
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 3rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- reorganize the header to keep the navigation links visibles en móviles sin menú desplegable y quitar el botón hamburguesa
- asegurar que el script de navegación sólo gestione el estado sticky sin clases ocultas para el menú
- ajustar la grilla de proyectos para mostrar dos columnas en pantallas grandes y formar un layout 2x2

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4180de8b0832c9347cdf642d2ce20