### PR TITLE
Adjust navigation layout for mobile and desktop

### DIFF
--- a/script.js
+++ b/script.js
@@ -454,7 +454,27 @@ function initializeNavigation() {
     window.addEventListener('scroll', handleScroll);
 
     if (navToggle && navMenu) {
+        const ensureMobileMenuVisible = () => {
+            if (window.innerWidth < 1024) {
+                navMenu.classList.remove('hidden');
+                if (!navMenu.classList.contains('flex')) {
+                    navMenu.classList.add('flex');
+                }
+                navToggle.setAttribute('aria-expanded', 'true');
+                navToggle.querySelector('.nav-toggle-bars')?.classList.remove('active');
+                return true;
+            }
+
+            return false;
+        };
+
+        ensureMobileMenuVisible();
+
         const toggleMenu = () => {
+            if (window.innerWidth < 1024) {
+                return;
+            }
+
             const isHidden = navMenu.classList.contains('hidden');
 
             if (isHidden) {
@@ -474,7 +494,11 @@ function initializeNavigation() {
         const navLinks = navMenu.querySelectorAll('a');
         navLinks.forEach(link => {
             link.addEventListener('click', () => {
-                if (window.innerWidth < 1024 && !navMenu.classList.contains('hidden')) {
+                if (window.innerWidth < 1024) {
+                    return;
+                }
+
+                if (!navMenu.classList.contains('hidden')) {
                     navMenu.classList.add('hidden');
                     navMenu.classList.remove('flex');
                     navToggle.setAttribute('aria-expanded', 'false');
@@ -495,15 +519,15 @@ function initializeNavigation() {
                 }
                 navToggle.setAttribute('aria-expanded', 'true');
                 navToggle.querySelector('.nav-toggle-bars')?.classList.remove('active');
-            } else if (wasDesktop) {
-                navMenu.classList.add('hidden');
-                navMenu.classList.remove('flex');
-                navToggle.setAttribute('aria-expanded', 'false');
-                navToggle.querySelector('.nav-toggle-bars')?.classList.remove('active');
             } else {
-                const isOpen = !navMenu.classList.contains('hidden');
-                navToggle.setAttribute('aria-expanded', String(isOpen));
-                navToggle.querySelector('.nav-toggle-bars')?.classList.toggle('active', isOpen);
+                const wasMenuForcedOpen = ensureMobileMenuVisible();
+
+                if (!wasMenuForcedOpen && wasDesktop) {
+                    navMenu.classList.add('hidden');
+                    navMenu.classList.remove('flex');
+                    navToggle.setAttribute('aria-expanded', 'false');
+                    navToggle.querySelector('.nav-toggle-bars')?.classList.remove('active');
+                }
             }
 
             wasDesktop = isDesktop;

--- a/style.css
+++ b/style.css
@@ -57,6 +57,61 @@ body {
     overflow: visible;
 }
 
+@media (max-width: 1023px) {
+    .site-header {
+        position: static;
+        padding: 0.75rem 0;
+    }
+
+    .nav {
+        border-radius: 0;
+        padding: 0.75rem 1.5rem;
+    }
+
+    .nav-toggle {
+        display: none !important;
+    }
+
+    .nav-menu {
+        display: flex !important;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.75rem;
+        position: static;
+        border-radius: 1.25rem;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background: rgba(15, 23, 42, 0.92);
+        padding: 1rem;
+        box-shadow: 0 18px 50px -18px rgba(14, 165, 233, 0.45);
+    }
+
+    .nav-menu .nav-link {
+        width: 100%;
+    }
+}
+
+@media (min-width: 1024px) {
+    .site-header {
+        padding: 0.85rem 0;
+    }
+
+    .nav {
+        padding-top: 0.75rem;
+        padding-bottom: 0.75rem;
+    }
+
+    .nav-logo {
+        width: 2.75rem;
+        height: 2.75rem;
+    }
+
+    .nav-actions .btn,
+    .nav-menu .nav-link {
+        padding-top: 0.5rem;
+        padding-bottom: 0.5rem;
+    }
+}
+
 .nav.scrolled {
     background: rgba(15, 23, 42, 0.9);
     box-shadow: 0 20px 60px -25px rgba(14, 165, 233, 0.55);


### PR DESCRIPTION
## Summary
- keep the mobile navigation static and always visible to avoid the dropdown issue
- tighten the desktop header spacing for a slimmer appearance

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e46a576564832cb7fefa5e88357d6d