### PR TITLE
Improve responsive navigation styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,6 +16,10 @@ body {
     overflow-x: hidden;
 }
 
+body.nav-open {
+    overflow: hidden;
+}
+
 .profile-image-frame {
     overflow: hidden;
     display: inline-flex;
@@ -88,29 +92,54 @@ body {
     }
 
     .nav {
-        border-radius: 0;
-        padding: 0.35rem 1.5rem;
-    }
-
-    .nav-toggle {
-        display: none !important;
+        border-radius: 1.25rem;
+        padding: 0.5rem 1rem;
+        align-items: center;
     }
 
     .nav-menu {
-        display: flex !important;
+        position: absolute;
+        top: calc(100% + 0.75rem);
+        left: 1rem;
+        right: 1rem;
         flex-direction: column;
         align-items: stretch;
         gap: 0.75rem;
-        position: static;
         border-radius: 1.25rem;
         border: 1px solid rgba(255, 255, 255, 0.08);
-        background: rgba(15, 23, 42, 0.92);
-        padding: 1rem;
-        box-shadow: 0 18px 50px -18px rgba(14, 165, 233, 0.45);
+        background: rgba(15, 23, 42, 0.95);
+        padding: 1.1rem;
+        box-shadow: 0 24px 55px -18px rgba(14, 165, 233, 0.55);
+        opacity: 0;
+        transform: translateY(-12px) scale(0.98);
+        pointer-events: none;
+        transition: opacity 0.25s ease, transform 0.25s ease;
+        max-height: calc(100vh - 120px);
+        overflow-y: auto;
+        z-index: 70;
+    }
+
+    .nav-menu.flex {
+        display: flex;
+    }
+
+    .nav-menu.open {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+        pointer-events: auto;
     }
 
     .nav-menu .nav-link {
         width: 100%;
+    }
+
+    body.nav-open::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 23, 42, 0.65);
+        backdrop-filter: blur(4px);
+        z-index: 40;
     }
 }
 
@@ -122,6 +151,9 @@ body {
     .nav {
         padding-top: 0.4rem;
         padding-bottom: 0.4rem;
+        margin-left: auto;
+        margin-right: auto;
+        max-width: 1040px;
     }
 
     .nav-logo {
@@ -133,6 +165,12 @@ body {
     .nav-menu .nav-link {
         padding-top: 0.32rem;
         padding-bottom: 0.32rem;
+    }
+}
+
+@media (min-width: 1280px) {
+    .nav {
+        max-width: 980px;
     }
 }
 
@@ -188,6 +226,12 @@ body {
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.85);
     transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.nav-toggle[aria-expanded="true"] {
+    border-color: rgba(6, 182, 212, 0.45);
+    background: rgba(6, 182, 212, 0.18);
+    box-shadow: 0 12px 28px -16px rgba(6, 182, 212, 0.55);
 }
 
 .nav-toggle-bars.active span:nth-child(1) {


### PR DESCRIPTION
## Summary
- redesign the mobile navigation into an animated overlay drawer with background blur and scroll locking
- update the navigation script to properly toggle the menu on mobile, including outside-click and Escape handling
- narrow the desktop navigation container for a slimmer header presentation

## Testing
- Manual verification by serving the site locally (`python -m http.server 8000`) and checking the navigation toggle


------
https://chatgpt.com/codex/tasks/task_e_68e5ca274e7c832cb286a70b57bf6e42